### PR TITLE
Deep dup attributes (useful when some attributes are a Hash)

### DIFF
--- a/lib/core_ext/object/deep_dup.rb
+++ b/lib/core_ext/object/deep_dup.rb
@@ -1,0 +1,55 @@
+require 'core_ext/object/duplicable'
+
+# Taken from ActiveSupport
+
+class Object
+  # Returns a deep copy of object if it's duplicable. If it's
+  # not duplicable, returns +self+.
+  #
+  #   object = Object.new
+  #   dup    = object.deep_dup
+  #   dup.instance_variable_set(:@a, 1)
+  #
+  #   object.instance_variable_defined?(:@a) # => false
+  #   dup.instance_variable_defined?(:@a)    # => true
+  def deep_dup
+    duplicable? ? dup : self
+  end
+end
+
+class Array
+  # Returns a deep copy of array.
+  #
+  #   array = [1, [2, 3]]
+  #   dup   = array.deep_dup
+  #   dup[1][2] = 4
+  #
+  #   array[1][2] # => nil
+  #   dup[1][2]   # => 4
+  def deep_dup
+    map(&:deep_dup)
+  end
+end
+
+class Hash
+  # Returns a deep copy of hash.
+  #
+  #   hash = { a: { b: 'b' } }
+  #   dup  = hash.deep_dup
+  #   dup[:a][:c] = 'c'
+  #
+  #   hash[:a][:c] # => nil
+  #   dup[:a][:c]  # => "c"
+  def deep_dup
+    hash = dup
+    each_pair do |key, value|
+      if key.frozen? && ::String === key
+        hash[key] = value.deep_dup
+      else
+        hash.delete(key)
+        hash[key.deep_dup] = value.deep_dup
+      end
+    end
+    hash
+  end
+end

--- a/lib/core_ext/object/duplicable.rb
+++ b/lib/core_ext/object/duplicable.rb
@@ -1,0 +1,100 @@
+# Taken from ActiveSupport
+
+#--
+# Most objects are cloneable, but not all. For example you can't dup +nil+:
+#
+#   nil.dup # => TypeError: can't dup NilClass
+#
+# Classes may signal their instances are not duplicable removing +dup+/+clone+
+# or raising exceptions from them. So, to dup an arbitrary object you normally
+# use an optimistic approach and are ready to catch an exception, say:
+#
+#   arbitrary_object.dup rescue object
+#
+# Rails dups objects in a few critical spots where they are not that arbitrary.
+# That rescue is very expensive (like 40 times slower than a predicate), and it
+# is often triggered.
+#
+# That's why we hardcode the following cases and check duplicable? instead of
+# using that rescue idiom.
+#++
+class Object
+  # Can you safely dup this object?
+  #
+  # False for +nil+, +false+, +true+, symbol, number, method objects;
+  # true otherwise.
+  def duplicable?
+    true
+  end
+end
+
+class NilClass
+  # +nil+ is not duplicable:
+  #
+  #   nil.duplicable? # => false
+  #   nil.dup         # => TypeError: can't dup NilClass
+  def duplicable?
+    false
+  end
+end
+
+class FalseClass
+  # +false+ is not duplicable:
+  #
+  #   false.duplicable? # => false
+  #   false.dup         # => TypeError: can't dup FalseClass
+  def duplicable?
+    false
+  end
+end
+
+class TrueClass
+  # +true+ is not duplicable:
+  #
+  #   true.duplicable? # => false
+  #   true.dup         # => TypeError: can't dup TrueClass
+  def duplicable?
+    false
+  end
+end
+
+class Symbol
+  # Symbols are not duplicable:
+  #
+  #   :my_symbol.duplicable? # => false
+  #   :my_symbol.dup         # => TypeError: can't dup Symbol
+  def duplicable?
+    false
+  end
+end
+
+class Numeric
+  # Numbers are not duplicable:
+  #
+  #  3.duplicable? # => false
+  #  3.dup         # => TypeError: can't dup Integer
+  def duplicable?
+    false
+  end
+end
+
+require "bigdecimal"
+class BigDecimal
+  # BigDecimals are duplicable:
+  #
+  # BigDecimal.new("1.2").duplicable? # => true
+  # BigDecimal.new("1.2").dup         # => #<BigDecimal:...,'0.12E1',18(18)>
+  def duplicable?
+    true
+  end
+end
+
+class Method
+  # Methods are not duplicable:
+  #
+  #  method(:puts).duplicable? # => false
+  #  method(:puts).dup         # => TypeError: allocator undefined for Method
+  def duplicable?
+    false
+  end
+end

--- a/lib/munson/document.rb
+++ b/lib/munson/document.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/object/deep_dup"
+require 'core_ext/object/deep_dup'
 
 module Munson
   class Document
@@ -12,7 +12,7 @@ module Munson
 
       if jsonapi_document[:data] && jsonapi_document[:data][:attributes]
         @original_attributes = jsonapi_document[:data][:attributes]
-        @attributes          = jsonapi_document[:data][:attributes]#.deep_dup
+        @attributes          = jsonapi_document[:data][:attributes].deep_dup
       else
         @original_attributes = {}
         @attributes          = {}

--- a/lib/munson/document.rb
+++ b/lib/munson/document.rb
@@ -9,8 +9,8 @@ module Munson
       @jsonapi_document = jsonapi_document
 
       if jsonapi_document[:data] && jsonapi_document[:data][:attributes]
-        @original_attributes = jsonapi_document[:data][:attributes].clone
-        @attributes          = jsonapi_document[:data][:attributes].clone
+        @original_attributes = jsonapi_document[:data][:attributes].deep_dup
+        @attributes          = jsonapi_document[:data][:attributes].deep_dup
       else
         @original_attributes = {}
         @attributes          = {}

--- a/lib/munson/document.rb
+++ b/lib/munson/document.rb
@@ -1,4 +1,4 @@
-require 'deep_clone'
+require "active_support/core_ext/object/deep_dup"
 
 module Munson
   class Document
@@ -11,8 +11,8 @@ module Munson
       @jsonapi_document = jsonapi_document
 
       if jsonapi_document[:data] && jsonapi_document[:data][:attributes]
-        @original_attributes = deep_clone jsonapi_document[:data][:attributes]
-        @attributes          = deep_clone jsonapi_document[:data][:attributes]
+        @original_attributes = jsonapi_document[:data][:attributes].deep_dup
+        @attributes          = jsonapi_document[:data][:attributes].deep_dup
       else
         @original_attributes = {}
         @attributes          = {}
@@ -119,11 +119,9 @@ module Munson
       relationships[name] ? relationships[name][:data] : nil
     end
 
-    private
-
     # @param [Hash] relationship from JSONAPI relationships hash
     # @return [Munson::Document,nil] the included relationship, if found
-    def find_included_item(relationship)
+    private def find_included_item(relationship)
       resource = included.find do |included_resource|
         included_resource[:type] == relationship[:type] &&
           included_resource[:id] == relationship[:id]
@@ -139,10 +137,6 @@ module Munson
         Try adding `include=#{relationship[:type]}` to your query.
         ERR
       end
-    end
-
-    def deep_clone(obj)
-      ::DeepClone.clone obj
     end
   end
 end

--- a/lib/munson/document.rb
+++ b/lib/munson/document.rb
@@ -1,3 +1,5 @@
+require 'deep_clone'
+
 module Munson
   class Document
     attr_accessor :id
@@ -9,8 +11,8 @@ module Munson
       @jsonapi_document = jsonapi_document
 
       if jsonapi_document[:data] && jsonapi_document[:data][:attributes]
-        @original_attributes = jsonapi_document[:data][:attributes].deep_dup
-        @attributes          = jsonapi_document[:data][:attributes].deep_dup
+        @original_attributes = deep_clone jsonapi_document[:data][:attributes]
+        @attributes          = deep_clone jsonapi_document[:data][:attributes]
       else
         @original_attributes = {}
         @attributes          = {}
@@ -117,9 +119,11 @@ module Munson
       relationships[name] ? relationships[name][:data] : nil
     end
 
+    private
+
     # @param [Hash] relationship from JSONAPI relationships hash
     # @return [Munson::Document,nil] the included relationship, if found
-    private def find_included_item(relationship)
+    def find_included_item(relationship)
       resource = included.find do |included_resource|
         included_resource[:type] == relationship[:type] &&
           included_resource[:id] == relationship[:id]
@@ -135,6 +139,10 @@ module Munson
         Try adding `include=#{relationship[:type]}` to your query.
         ERR
       end
+    end
+
+    def deep_clone(obj)
+      ::DeepClone.clone obj
     end
   end
 end

--- a/lib/munson/document.rb
+++ b/lib/munson/document.rb
@@ -11,8 +11,8 @@ module Munson
       @jsonapi_document = jsonapi_document
 
       if jsonapi_document[:data] && jsonapi_document[:data][:attributes]
-        @original_attributes = jsonapi_document[:data][:attributes].deep_dup
-        @attributes          = jsonapi_document[:data][:attributes].deep_dup
+        @original_attributes = jsonapi_document[:data][:attributes]
+        @attributes          = jsonapi_document[:data][:attributes]#.deep_dup
       else
         @original_attributes = {}
         @attributes          = {}

--- a/munson.gemspec
+++ b/munson.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday"
   spec.add_dependency "faraday_middleware"
-  spec.add_dependency "activesupport", '~> 4'
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/munson.gemspec
+++ b/munson.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday"
   spec.add_dependency "faraday_middleware"
+  spec.add_dependency "ruby_deep_clone"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/munson.gemspec
+++ b/munson.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday"
   spec.add_dependency "faraday_middleware"
-  spec.add_dependency "ruby_deep_clone"
+  spec.add_dependency "activesupport", '~> 4'
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/munson/connection_spec.rb
+++ b/spec/munson/connection_spec.rb
@@ -26,7 +26,9 @@ describe Munson::Connection do
 
         body = connection.get.body
         keys = body[:included].first[:attributes].keys
-        expect(keys).to eq([:first_name, :last_name, :twitter, :post_count, :created_at])
+        expect(keys).to eq(
+          [:first_name, :last_name, :twitter, :post_count, :created_at, :meta]
+        )
       end
 
       it "formats request body keys" do

--- a/spec/support/app/blog.rb
+++ b/spec/support/app/blog.rb
@@ -19,6 +19,7 @@ class Person < Munson::Resource
   attribute :twitter, :string
   attribute :created_at, :time, default: ->{ Time.now }, serialize: ->(val){ val.to_s }
   attribute :post_count, :integer
+  attribute :meta, :hash
 end
 
 class Comment < Munson::Resource

--- a/spec/support/responses/articles_include_author_comments.json
+++ b/spec/support/responses/articles_include_author_comments.json
@@ -43,7 +43,10 @@
       "twitter": "chauncy",
 
       "post-count": 1,
-      "created-at": "2016-05-23T18:25:43.511Z"
+      "created-at": "2016-05-23T18:25:43.511Z",
+      "meta": {
+        "last-ip": "127.0.0.1"
+      }
     },
     "links": {
       "self": "http://example.com/people/9"

--- a/spec/usage_spec.rb
+++ b/spec/usage_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe 'Usage' do
     author.first_name = "Tomas"
     author.last_name = "Blunderbee"
     author.twitter = "blunderz"
+    author.meta['spam-score'] = "0"
     expect(author.first_name).to eq 'Tomas'
 
     json = {
@@ -50,7 +51,11 @@ RSpec.describe 'Usage' do
         attributes: {
           "first-name" => "Tomas",
           "last-name" => "Blunderbee",
-          "twitter" => "blunderz"
+          "twitter" => "blunderz",
+          "meta" => {
+            "last-ip" => "127.0.0.1",
+            "spam-score" => "0"
+          }
         }
       }
     }


### PR DESCRIPTION
Otherwise `@attributes` and `@original_attributes` refer to the same instance, and hash attributes will never get pushed to the remote server